### PR TITLE
Fix deployment binary format & gcloud usage issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,8 @@ deploy-server-frontend: build-server-frontend
 
 .PHONY: build-server-game
 build-server-game: export GOPATH=${GAME_GOPATH}:${GAME_GOPATH}/vendor
+build-server-game: export GOOS=linux
+build-server-game: export GOARCH=amd64
 build-server-game: install-deps-server-game
 	rm -f ${GOBIN}/server-game
 	cd ${GAME_DIR} && go build -o ${GOBIN}/server-game
@@ -152,7 +154,7 @@ build-server-game-image: build-server-game server-game.tag
 .PHONY: push-server-game
 push-server-game: tag=$(shell cat server-game.tag)
 push-server-game: build-server-game-image
-	gcloud docker push ${tag}
+	gcloud docker -- push ${tag}
 
 .PHONY: deploy-server-game
 deploy-server-game: tag=$(shell cat server-game.tag)


### PR DESCRIPTION
server-game deployments were failing in the logs with "exec format error" when I deployed from OSX.  Also fix deploy commend itself failing due to the syntax of the 'gcloud docker push' command.  This appears to have changed in the latest version of the gcloud SDK (148.0.1).

This pull request consists of two changes in the Makefile:
* cross build server-game for linux/amd64 (so building on OSX works)
* 'gcloud docker push <foo>' is supposed to be 'gcloud docker -- push <foo>"